### PR TITLE
Forced encoding to be utf-8

### DIFF
--- a/zalgo/__main__.py
+++ b/zalgo/__main__.py
@@ -37,7 +37,7 @@ def command_line_runner():
         parser.print_help()
         return
     else:
-        zalgotext = convert_zalgo(args.text, args.intensity, args.copy)
+        zalgotext = convert_zalgo(args.text, args.intensity, args.copy).encode('utf-8').strip()
 
         if not args.copy:
             print(zalgotext)


### PR DESCRIPTION
I was getting the following error:
UnicodeEncodeError: 'ascii' codec can't encode characters in position 1-103: ordinal not in range(128)
Presumably because the default encoding was not specified, shouldn't break it on any other machines since I assume the "intended" encoding is utf-8 anyway.